### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "manual": "node_modules/protractor/bin/protractor ./test/system/conf.js"
   },
   "dependencies": {
-    "allure-js-commons": "1.0.2"
+    "allure-js-commons": "1.1.4"
   },
   "devDependencies": {
     "protractor": "2.1.0",


### PR DESCRIPTION
The version of allure-js-commons bundled into this package is 1.0.2 so the runtime.js is missing some capabilities as compared to the one implemented in version 1.1.4

Missing methods: addLabel, addArgument, addEnvironment, description and more

Bundling allure-ja-commons version 1.1.4 into the current jasmine-allure-plugin solve the issue
